### PR TITLE
Fix async mode sending metrics too rarely

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -277,7 +277,7 @@ fn main() {
             })
         .expect("starting thread for running consul");
     } else {
-        info!(log, "consul is diabled, starting as leader");
+        info!(log, "consul is disabled, starting as leader");
         IS_LEADER.store(true, Ordering::SeqCst);
         CAN_LEADER.store(false, Ordering::SeqCst);
     }
@@ -571,7 +571,7 @@ fn main() {
                                 bufsize,
                                 i,
                                 readbuf,
-                                task_queue_size * bufsize,
+                                task_queue_size,
                                 );
 
                             runtime.spawn(server.into_future());

--- a/src/server.rs
+++ b/src/server.rs
@@ -96,7 +96,7 @@ impl IntoFuture for StatsdServer {
                                     bufsize,
                                     next,
                                     received,
-                                    buf_queue_size * bufsize,
+                                    buf_queue_size,
                                 ).into_future()
                             }),
                     );


### PR DESCRIPTION
With multimessage = false metric buffer was only dumped every `task-queue-size * bufsize` packets. This PR makes quick fix changing rate to every `task-queue-size` packets.