### PR TITLE
fix "attempt to substract with overflow" in parser

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -39,14 +39,12 @@ impl Task {
         match self {
             Task::Parse(buf) => {
                 let mut input: &[u8] = &buf;
-                let mut size_left = buf.len();
                 let mut parser = metric_parser::<Float>();
                 loop {
                     match parser.parse_stream_consumed(&mut input) {
                         FastResult::ConsumedOk(((name, metric), rest)) => {
                             INGRESS_METRICS.fetch_add(1, Ordering::Relaxed);
-                            size_left -= rest.len();
-                            if size_left == 0 {
+                            if rest.len() == 0 {
                                 break;
                             }
                             input = rest;


### PR DESCRIPTION
```
thread 'bioyino_cnt0' panicked at 'attempt to subtract with overflow', src/task.rs:48:29
note: Run with `RUST_BACKTRACE=1` for a backtrace.
Oct 23 19:24:18.760 INFO error sending snapshot, error: error sending task to worker thread, program: bioyino
```